### PR TITLE
pass laundry reminderInfo from frontend to backend

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,13 +1,12 @@
 /* global self, indexedDB */
 self.addEventListener('push', e => {
   const payload = e.data.json()
-  const { machineID, hallID, reminderID, type } = payload
+  const { machineID, hallID, reminderID, machineType: type } = payload
   const iconDir = type === 'washer' ? 'washer-done' : 'dryer-done'
   self.registration.showNotification('Penn Basics', {
     body: `Your ${type}’s done!`,
     icon: `/img/${iconDir}.png`,
     requireInteraction: true,
-    // icon: '../../../public/android-chrome-256x256.png'
   })
   const request = indexedDB.open('LocalDB', 1)
 

--- a/src/frontend/actions/laundry_actions.js
+++ b/src/frontend/actions/laundry_actions.js
@@ -419,7 +419,7 @@ export const getReminders = () => {
   }
 }
 
-export const addReminder = (machineID, hallID, hallName) => {
+export const addReminder = (machineID, hallID, machineType, timeRemaining) => {
   return dispatch => {
     try {
       navigator.serviceWorker.ready.then(async registration => {
@@ -443,7 +443,8 @@ export const addReminder = (machineID, hallID, hallName) => {
           subscription,
           machineID,
           hallID,
-          hallName,
+          machineType,
+          timeRemaining,
           reminderID,
         })
       })

--- a/src/frontend/components/laundry/LaundryVenue.js
+++ b/src/frontend/components/laundry/LaundryVenue.js
@@ -145,7 +145,6 @@ class LaundryVenue extends Component {
                 machineType="washer"
                 allMachines={machines}
                 laundryHallId={hallURLId}
-                hallName={hallName}
                 reminders={reminders}
                 dispatchAddReminder={dispatchAddReminder}
                 enableReminder={enableReminder}
@@ -162,7 +161,6 @@ class LaundryVenue extends Component {
                 machineType="dryer"
                 allMachines={machines}
                 laundryHallId={hallURLId}
-                hallName={hallName}
                 reminders={reminders}
                 dispatchAddReminder={dispatchAddReminder}
                 enableReminder={enableReminder}
@@ -255,8 +253,8 @@ const mapDispatchToProps = dispatch => ({
     dispatch(removeFavorite(hallURLId)),
   dispatchGetLaundryHall: (hallId, intervalID) =>
     dispatch(getLaundryHall(hallId, intervalID)),
-  dispatchAddReminder: (machineID, hallID, hallName) =>
-    dispatch(addReminder(machineID, hallID, hallName)),
+  dispatchAddReminder: (machineID, hallID, machineType, timeRemaining) =>
+    dispatch(addReminder(machineID, hallID, machineType, timeRemaining)),
   dispatchRemoveReminder: () => dispatch(removeReminder()),
   dispatchGetReminders: () => dispatch(getReminders()),
 })

--- a/src/frontend/components/laundry/MachineAvailability.js
+++ b/src/frontend/components/laundry/MachineAvailability.js
@@ -212,7 +212,6 @@ MachineAvailability.defaultProps = {
   machineType: '',
   allMachines: [],
   laundryHallId: null,
-  hallName: '',
   reminders: [],
   enableReminder: false,
   dispatchAddReminder: null,

--- a/src/frontend/components/laundry/MachineAvailability.js
+++ b/src/frontend/components/laundry/MachineAvailability.js
@@ -229,7 +229,6 @@ MachineAvailability.propTypes = {
   machineType: PropTypes.string,
   allMachines: PropTypes.array, // eslint-disable-line
   laundryHallId: PropTypes.number,
-  hallName: PropTypes.string,
   reminders: PropTypes.arrayOf(PropTypes.object),
   dispatchAddReminder: PropTypes.func,
   enableReminder: PropTypes.bool,

--- a/src/frontend/components/laundry/MachineAvailability.js
+++ b/src/frontend/components/laundry/MachineAvailability.js
@@ -44,12 +44,13 @@ const BellIcon = s.span`
 const handleReminder = (
   machineID,
   hallID,
-  hallName,
   dispatchAddReminder,
-  reminded
+  reminded,
+  machineType,
+  timeRemaining
 ) => {
   if (!reminded) {
-    dispatchAddReminder(machineID, hallID, hallName)
+    dispatchAddReminder(machineID, hallID, machineType, timeRemaining)
   }
 }
 
@@ -61,7 +62,7 @@ const Bell = ({
   id,
   laundryHallId,
   dispatchAddReminder,
-  hallName,
+  machineType,
 }) => {
   if (!enableReminder || timeRemaining <= 0 || !dispatchAddReminder) {
     return null
@@ -74,9 +75,10 @@ const Bell = ({
           handleReminder(
             id,
             laundryHallId,
-            hallName,
             dispatchAddReminder,
-            reminded
+            reminded,
+            machineType,
+            timeRemaining
           )
         }
       >
@@ -103,8 +105,8 @@ Bell.defaultProps = {
   reminded: false,
   id: null,
   laundryHallId: null,
-  hallName: null,
   dispatchAddReminder: null,
+  machineType: '',
 }
 
 Bell.propTypes = {
@@ -114,7 +116,7 @@ Bell.propTypes = {
   id: PropTypes.number,
   laundryHallId: PropTypes.number,
   dispatchAddReminder: PropTypes.func,
-  hallName: PropTypes.string,
+  machineType: PropTypes.string,
 }
 
 const MachineAvailability = ({
@@ -123,7 +125,6 @@ const MachineAvailability = ({
   machineType,
   allMachines,
   laundryHallId,
-  hallName,
   reminders,
   dispatchAddReminder,
   enableReminder,
@@ -191,7 +192,7 @@ const MachineAvailability = ({
                         id={id}
                         laundryHallId={laundryHallId}
                         dispatchAddReminder={dispatchAddReminder}
-                        hallName={hallName}
+                        machineType={machineType}
                       />
                     </td>
                   </tr>

--- a/src/server/routes/laundry.js
+++ b/src/server/routes/laundry.js
@@ -1,9 +1,6 @@
 const router = require('express').Router()
 const HttpStatus = require('http-status-codes')
 const webpush = require('web-push')
-const axios = require('axios')
-
-const BASE = 'http://api.pennlabs.org'
 
 const isValidNumericId = id => {
   if (id === null || id === undefined) return false
@@ -19,23 +16,23 @@ module.exports = function laundryRouter() {
 
     // a unique reminderID is used to distinguish between multiple reminders
     // that have the same hallID and machineID
-    const { subscription, machineID, hallID, reminderID } = req.body
+    const {
+      subscription,
+      machineID,
+      hallID,
+      machineType,
+      reminderID,
+    } = req.body
+
+    let { timeRemaining } = req.body
+    timeRemaining =
+      timeRemaining !== 0 ? Number(timeRemaining) * 60 * 1000 : 20000
+    // timeRemaining = 2000
 
     if (!isValidNumericId(hallID)) {
       res.status(HttpStatus.BAD_REQUEST).send('Missing hallID')
       return
     }
-
-    // fetch the time remaining using Labs API
-    const axiosResponse = await axios.get(`${BASE}/laundry/hall/${hallID}`)
-    const { data } = axiosResponse
-    const machine = data.machines.details.filter(
-      detail => detail.id === machineID
-    )
-    const { type, time_remaining: timeRemaining } = machine[0]
-    const timeRemainingFormatted =
-      timeRemaining !== 0 ? Number(timeRemaining) * 60 * 1000 : 20000
-    // timeRemainingFormatted = 2000
 
     // set a timeout that equals to the timeRemaining
     setTimeout(async () => {
@@ -43,14 +40,14 @@ module.exports = function laundryRouter() {
         // use webpush to instruct the service worker to push notification
         await webpush.sendNotification(
           subscription,
-          JSON.stringify({ machineID, hallID, reminderID, type }) // payload received by the service worker
+          JSON.stringify({ machineID, hallID, reminderID, machineType }) // payload received by the service worker
         )
         // respond to frontend until the instruction is received by the service worker
         res.status(200).json({})
       } catch (err) {
         res.status(200).json({ error: err.message })
       }
-    }, timeRemainingFormatted)
+    }, timeRemaining)
   })
 
   return router


### PR DESCRIPTION
- instead of fetching relevant laundry info at backend to set reminder, directly pass info from frontend to backend
- reduce chance of failed reminders because of not being able to call laundry API
- clean up code